### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[RonanJT/rust-http](https://github.com/RonanJT/rust-http.git) |  | []() | 

--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[RonanJT/rust-http](https://github.com/RonanJT/rust-http.git) |  | []() | 
+[RonanJT/rust-http-jx](https://github.com/RonanJT/rust-http-jx.git) |  | []() | 

--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[RonanJT/rust-http-jx](https://github.com/RonanJT/rust-http-jx.git) |  | []() | 
+[RonanJT/rust-http](https://github.com/RonanJT/rust-http.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: RonanJT
-  repo: rust-http
-  url: https://github.com/RonanJT/rust-http.git
+  repo: rust-http-jx
+  url: https://github.com/RonanJT/rust-http-jx.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: RonanJT
-  repo: rust-http-jx
-  url: https://github.com/RonanJT/rust-http-jx.git
+  repo: rust-http
+  url: https://github.com/RonanJT/rust-http.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: RonanJT
+  repo: rust-http
+  url: https://github.com/RonanJT/rust-http.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/ronanjt-rust-http-jx-sr.yaml
+++ b/repositories/templates/ronanjt-rust-http-jx-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: RonanJT
+    provider: github
+    repository: rust-http-jx
+  name: ronanjt-rust-http-jx
+spec:
+  description: Imported application for RonanJT/rust-http-jx
+  httpCloneURL: https://github.com/RonanJT/rust-http-jx.git
+  org: RonanJT
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: rust-http-jx
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/RonanJT/rust-http-jx.git

--- a/repositories/templates/ronanjt-rust-http-sr.yaml
+++ b/repositories/templates/ronanjt-rust-http-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "2"
   creationTimestamp: null
   labels:
     owner: RonanJT

--- a/repositories/templates/ronanjt-rust-http-sr.yaml
+++ b/repositories/templates/ronanjt-rust-http-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: RonanJT
+    provider: github
+    repository: rust-http
+  name: ronanjt-rust-http
+spec:
+  description: Imported application for RonanJT/rust-http
+  httpCloneURL: https://github.com/RonanJT/rust-http.git
+  org: RonanJT
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: rust-http
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/RonanJT/rust-http.git


### PR DESCRIPTION
Update [RonanJT/IndependentAPI](https://github.com/RonanJT/IndependentAPI.git) 

Command run was `jx import IndependentAPI --git-public`
<hr />

Update [RonanJT/rust-http](https://github.com/RonanJT/rust-http.git) 

Command run was `jx create project`
<hr />

Update [RonanJT/rust-http-jx](https://github.com/RonanJT/rust-http-jx.git) 

Command run was `jx create quickstart --git-public`
<hr />

Update [RonanJT/rust-http](https://github.com/RonanJT/rust-http.git) 

Command run was `jx create quickstart --git-public`